### PR TITLE
Fixed styles of disabled dates and header styles of month selector and year selector

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,6 @@ module.exports = {
             2,
             'always'
         ],
-        'linebreak-style': [2, 'windows'],
         'react/prop-types': [0]
     },
     env: {

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.idea

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -159,6 +159,7 @@ export default class DaysGridView extends Component {
           disabledDates={() => true}
           disabledDatesTextStyle={this.props.disabledDatesTextStyle}
           textStyle={this.props.textStyle}
+          customDatesStyles={this.props.customDatesStyles}
         />
       )
     });

--- a/CalendarPicker/Month.js
+++ b/CalendarPicker/Month.js
@@ -60,7 +60,7 @@ export default function Month(props) {
           </Text>
         </TouchableOpacity>
         :
-        <Text style={[textStyle, styles.disabledText]}>
+        <Text style={styles.disabledDatesTextStyle}>
           { monthName }
         </Text>
       }

--- a/CalendarPicker/MonthSelector.js
+++ b/CalendarPicker/MonthSelector.js
@@ -24,6 +24,7 @@ export default class MonthSelector extends Component {
       minDate,
       maxDate,
       onSelectMonth,
+      headerWrapperStyle,
     } = this.props;
 
     return (
@@ -33,6 +34,7 @@ export default class MonthSelector extends Component {
           textStyle={textStyle}
           title={title + currentYear}
           headingLevel={headingLevel}
+          headerWrapperStyle={headerWrapperStyle}
         />
         <MonthsGridView
           styles={styles}

--- a/CalendarPicker/MonthsHeader.js
+++ b/CalendarPicker/MonthsHeader.js
@@ -13,6 +13,7 @@ export default function MonthsHeader(props) {
     textStyle,
     headingLevel,
     title,
+    headerWrapperStyle,
   } = props;
 
   const accessibilityProps = { accessibilityRole: 'header' };
@@ -21,7 +22,7 @@ export default function MonthsHeader(props) {
   }
 
   return (
-    <View style={styles.headerWrapper}>
+    <View style={[styles.headerWrapper, headerWrapperStyle]}>
       <Text style={[styles.monthsHeaderText, textStyle]}>
         { title }
       </Text>

--- a/CalendarPicker/Year.js
+++ b/CalendarPicker/Year.js
@@ -59,7 +59,7 @@ export default function Year(props) {
           </Text>
         </TouchableOpacity>
         :
-        <Text style={[textStyle, styles.disabledText]}>
+        <Text style={styles.disabledDatesTextStyle}>
           { year }
         </Text>
       }

--- a/CalendarPicker/YearSelector.js
+++ b/CalendarPicker/YearSelector.js
@@ -44,6 +44,7 @@ export default class YearSelector extends Component {
       nextTitleStyle,
       headingLevel,
       onSelectYear,
+      headerWrapperStyle,
     } = this.props;
 
     return (
@@ -66,6 +67,7 @@ export default class YearSelector extends Component {
           nextTitleStyle={nextTitleStyle}
           onYearViewPrevious={this.handleOnYearViewPrevious}
           onYearViewNext={this.handleOnYearViewNext}
+          headerWrapperStyle={headerWrapperStyle}
         />
         <YearsGridView
           intialYear={this.state.initialYear}

--- a/CalendarPicker/YearsHeader.js
+++ b/CalendarPicker/YearsHeader.js
@@ -26,6 +26,7 @@ export default function YearsHeader(props) {
     onYearViewPrevious,
     onYearViewNext,
     headingLevel,
+    headerWrapperStyle,
   } = props;
 
   const disablePrevious = restrictNavigation && minDate && (minDate.year() >= year);
@@ -37,7 +38,7 @@ export default function YearsHeader(props) {
   }
 
   return (
-    <View style={styles.headerWrapper}>
+    <View style={[styles.headerWrapper, headerWrapperStyle]}>
       <Controls
         disabled={disablePrevious}
         label={previousTitle}

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -484,6 +484,7 @@ export default class CalendarPicker extends Component {
       onMonthChange,
       scrollable,
       horizontal,
+      disabledDatesTextStyle,
     } = this.props;
 
     let content;
@@ -491,7 +492,7 @@ export default class CalendarPicker extends Component {
     case 'months':
       content = (
         <MonthSelector
-          styles={styles}
+          styles={{ ...styles, disabledDatesTextStyle }}
           textStyle={textStyle}
           title={selectMonthTitle}
           currentYear={currentYear}
@@ -500,13 +501,14 @@ export default class CalendarPicker extends Component {
           maxDate={maxDate}
           onSelectMonth={this.handleOnSelectMonthYear}
           headingLevel={headingLevel}
+          headerWrapperStyle={headerWrapperStyle}
         />
       );
       break;
     case 'years':
       content = (
         <YearSelector
-          styles={styles}
+          styles={{ ...styles, disabledDatesTextStyle }}
           textStyle={textStyle}
           title={selectYearTitle}
           initialDate={moment(initialDate)}
@@ -523,6 +525,7 @@ export default class CalendarPicker extends Component {
           nextTitleStyle={nextTitleStyle}
           onSelectYear={this.handleOnSelectMonthYear}
           headingLevel={headingLevel}
+          headerWrapperStyle={headerWrapperStyle}
         />
       );
       break;


### PR DESCRIPTION
Fixed styles for disabled dates, months and years.
Fixed header style for month and year selectors.
Fixed header margin bottoms for MonthsHeader.js and YearsHeader.js.
Removed duplicate "linebreak-style" style for windows.
Updated .gitignore.